### PR TITLE
Fix bellisima price parsing

### DIFF
--- a/BellisimaAnalizer.py
+++ b/BellisimaAnalizer.py
@@ -33,13 +33,16 @@ def obtener_info_producto_bellisima(sku):
     # depending on the product state (on sale, regular, etc.).
     # Try several possible selectors before falling back to JSON/iframe parsing.
     precio_tag = (
-        soup_prod.select_one("span.price.price--large")
+        soup_prod.select_one("div.price-list span.price")
+        or soup_prod.select_one("span.price.price--large")
         or soup_prod.select_one("span.price-item--regular")
         or soup_prod.select_one("span.price.price--highlight")
         or soup_prod.select_one("span.price__regular")
     )
     if precio_tag:
-        precio = precio_tag.get_text(strip=True)
+        text = precio_tag.get_text(" ", strip=True)
+        m = re.search(r"\$\s*([0-9.,]+)", text)
+        precio = m.group(1) if m else text
 
     if not precio:
         for script in soup_prod.find_all("script", type="application/ld+json"):

--- a/scrapers.py
+++ b/scrapers.py
@@ -103,11 +103,14 @@ def search_bellisima_sku(sku: str, session: Optional[requests.Session] = None) -
 
     # Intentar extraer el precio de elementos visibles
     precio_tag = (
-        soup_prod.select_one("span.price-item--regular")
+        soup_prod.select_one("div.price-list span.price")
+        or soup_prod.select_one("span.price-item--regular")
         or soup_prod.select_one("span.price.price--highlight")
     )
     if precio_tag:
-        precio = precio_tag.get_text(strip=True)
+        text = precio_tag.get_text(" ", strip=True)
+        m = re.search(r"\$\s*([0-9.,]+)", text)
+        precio = m.group(1) if m else text
 
     # Intentar extraer el precio desde etiquetas JSON-LD
     if not precio:


### PR DESCRIPTION
## Summary
- tweak price selectors in `BellisimaAnalizer` and `scrapers` so new markup `<div class="price-list"><span class="price">...</span>` is parsed

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845dee7d7148326b5e87e3b07b12568